### PR TITLE
Interpret color based on player's in-game choice.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,7 @@ install:
 script:
   - npm test
   - npm run build
+
+cache:
+  directories:
+    - node_modules

--- a/src/components/LocalMap.jsx
+++ b/src/components/LocalMap.jsx
@@ -38,12 +38,22 @@ const styles = {
   .map(x => parseBinaryMap(x.payload))
   .filter(map => {
     return !map.pixels.equals(new Buffer(map.pixels.length))
-  }),
+  })
+  .distinctUntilChanged(),
   'map')
 @withStore(dispatcher
   .reduce(Database)
   .map(x => generateTreeFromDatabase(x))
   .map(x => x && x.Status.EffectColor)
+  .map(effectColor => {
+    let effectColors = effectColor.map(x => Math.round(x*255) )
+    let effect = {
+      red: effectColors[0],
+      green: effectColors[1],
+      blue: effectColors[2]
+    }
+    return `rgb(${effect.red},${effect.green},${effect.blue})`
+  })
   .distinctUntilChanged(),
   'effectColor')
 export default class LocalMap extends React.Component {
@@ -73,17 +83,7 @@ export default class LocalMap extends React.Component {
   updateMap = (map, effectColor) => {
     // Get next LocalMap
     this.context.sendCommand('RequestLocalMapSnapshot')
-
-    if (!effectColor) {
-      effectColor = [0.07999999821186066, 1, 0.09000000357627869]
-    }
-    effectColor = effectColor.map(x => Math.round(x*255) )
-
-    const redLevel = effectColor[0];
-    const greenLevel = effectColor[1];
-    const blueLevel = effectColor[2];
-
-    const fillStyle = `rgb(${redLevel},${greenLevel},${blueLevel})`
+    const fillStyle = effectColor;
 
     const {
       width,
@@ -123,7 +123,8 @@ export default class LocalMap extends React.Component {
         <PlayerArrow
           orientation={this.props.orientation || 0}
           x={0.5}
-          y={0.5}/>
+          y={0.5}
+          color={this.props.effectColor} />
       </div>
     )
   }

--- a/src/components/PlayerArrow.jsx
+++ b/src/components/PlayerArrow.jsx
@@ -45,7 +45,9 @@ export default class PlayerArrow extends React.Component {
         top: `${this.props.y * 100}%`,
         transform: `rotate(${this.props.orientation}deg)`
       })}>
-        <div style={styles.inner}/>
+        <div style={Object.assign({}, styles.inner, {
+          borderBottom: `30px solid ${this.props.color}`
+        })}/>
       </div>
     )
   }


### PR DESCRIPTION
This is definitely not the best implementation of #17, as I'm not sure how I should share the setup of the database (`generateTreeFromDatabase`). It would also be great to be able to color the player arrow too, which would involve mutating `PlayerArrow` too. First pass:

<img width="803" alt="screenshot 2015-12-10 12 57 34" src="https://cloud.githubusercontent.com/assets/836375/11725235/37431ad8-9f3e-11e5-8195-d2397e313c02.png">
