### PR TITLE
Cache the electron pre-builts cross-platform

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,3 +16,4 @@ script:
 cache:
   directories:
     - node_modules
+    - $HOME/.electron


### PR DESCRIPTION
This is going to save a boat load of time on builds. `~/.electron` is where the electron pre-builts end up, not within `node_modules`.
